### PR TITLE
fix bug: Fix LottiePlayer ref and client-only loading for mobile comp…

### DIFF
--- a/src/components/HomeSection/index.jsx
+++ b/src/components/HomeSection/index.jsx
@@ -11,7 +11,7 @@ import AnimatedDisplay from '../AnimatedDisplay';
 import Paragraph from '../Paragraph';
 import { motion } from 'framer-motion';
 import Player from '../LottiePlayer';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 
 function HomeSection({
   id,
@@ -22,11 +22,26 @@ function HomeSection({
   texts = '',
 }) {
   const playerRef = useRef(null);
-  useEffect(() => {
-    if (playerRef && id === activeSectionId) {
-      playerRef.current.play();
+  const [isReady, setIsReady] = useState(false);
+
+  const handleEvent = useCallback((event) => {
+    if (event === 'load') {
+      setIsReady(true);
     }
-  }, [activeSectionId, id]);
+  }, []);
+
+  useEffect(() => {
+    if (id !== activeSectionId || !isReady) return;
+
+    const inst = playerRef.current;
+    if (inst && typeof inst.play === 'function') {
+      // Reset to beginning and play
+      if (typeof inst.setSeeker === 'function') {
+        inst.setSeeker(0, false);
+      }
+      inst.play();
+    }
+  }, [activeSectionId, id, isReady]);
 
   return (
     <div id={id} className="section home_section fp-auto-height-responsive">
@@ -37,6 +52,7 @@ function HomeSection({
             keepLastFrame
             loop={false}
             src={lottie}
+            onEvent={handleEvent}
             style={{
               width: '100%',
               height: '100%',

--- a/src/components/LottiePlayer/index.jsx
+++ b/src/components/LottiePlayer/index.jsx
@@ -1,11 +1,21 @@
-import dynamic from 'next/dynamic';
+import { forwardRef, useEffect, useState } from 'react';
 
-const Player = dynamic(
-  async () => {
-    const ReactLottie = await import('@lottiefiles/react-lottie-player');
-    return ReactLottie.Player;
-  },
-  { ssr: false }
-);
+const Player = forwardRef((props, ref) => {
+  const [PlayerComponent, setPlayerComponent] = useState(null);
+
+  useEffect(() => {
+    import('@lottiefiles/react-lottie-player').then((mod) => {
+      setPlayerComponent(() => mod.Player);
+    });
+  }, []);
+
+  if (!PlayerComponent) {
+    return null;
+  }
+
+  return <PlayerComponent ref={ref} {...props} />;
+});
+
+Player.displayName = 'Player';
 
 export default Player;


### PR DESCRIPTION
This pull request refactors how the Lottie animation player is loaded and managed in the `HomeSection` component, improving both reliability and user experience. The main changes are the switch from Next.js dynamic import to a custom React `forwardRef` wrapper for the player, and the addition of logic to ensure animations only play when fully loaded and the section is active.

**Lottie Player Loading and Refactoring:**

* Replaced Next.js `dynamic` import with a custom `forwardRef` React component in `LottiePlayer`, using `useEffect` and `useState` to asynchronously load the Lottie player and expose the ref correctly. This improves compatibility and control over the player component. (`src/components/LottiePlayer/index.jsx`)

**Animation Playback Control Improvements:**

* Added `isReady` state and `handleEvent` callback in `HomeSection` to track when the Lottie animation is loaded, ensuring playback only starts when the animation is ready and the section is active. (`src/components/HomeSection/index.jsx`)
* Updated the effect logic in `HomeSection` to reset the animation to the beginning and play only when appropriate, preventing premature playback and improving user experience. (`src/components/HomeSection/index.jsx`)
* Passed the new `onEvent` prop to the Lottie player to trigger readiness logic, integrating the new event handling mechanism. (`src/components/HomeSection/index.jsx`)
